### PR TITLE
alleviating common errors in pygnme installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif(WITH_OPENMP)
 
 # Look for linear algebra libraries
 find_package(BLAS)
+find_package(CBLAS)
 find_package(LAPACK)
 
 # Setup Armadillo paths

--- a/libgnme/wick/CMakeLists.txt
+++ b/libgnme/wick/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRC
 
 add_library(gnme_wick ${SRC})
 target_include_directories(gnme_wick PUBLIC "${$LIBGNME_SOURCE_DIR}")
-target_link_libraries(gnme_wick gnme_utils)
+target_link_libraries(gnme_wick gnme_utils "${BLAS_LIBRARIES}" )
+include_directories("${CBLAS_LIBRARIES}")
 
 install(TARGETS gnme_wick DESTINATION lib)


### PR DESCRIPTION
With the recent update, libgnme is an external dependency in [Pygnme](https://github.com/BoothGroup/pygnme) and this minor dependency fix avoids installation errors. 