### PR TITLE
Small modification rectifies issues within Vayesta's GitHub CI configuration, ensuring seamless installation of pygnme as a dependency.

### DIFF
--- a/libgnme/wick/CMakeLists.txt
+++ b/libgnme/wick/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRC
 add_library(gnme_wick ${SRC})
 target_include_directories(gnme_wick PUBLIC "${$LIBGNME_SOURCE_DIR}")
 target_link_libraries(gnme_wick gnme_utils "${BLAS_LIBRARIES}" )
+target_link_libraries(gnme_wick gnme_utils "${LAPACK_LIBRARIES}" )
 include_directories("${CBLAS_LIBRARIES}")
 
 install(TARGETS gnme_wick DESTINATION lib)


### PR DESCRIPTION
fix for lapack dependencies: Installation of pygnme interface in Github CI setup of Vayesta