### PR TITLE
Fix linking errors caused by non-standard code

### DIFF
--- a/libgnme/wick/CMakeLists.txt
+++ b/libgnme/wick/CMakeLists.txt
@@ -3,10 +3,7 @@ set(SRC
     one_body_uscf.C
     two_body_rscf.C
     two_body_uscf.C
-    wick_base_overlap.C
-    wick_base_rdm.C
-    wick_base_one_body.C
-    wick_base_two_body.C
+    wick_base.C
     wick_orbitals.C
     wick_rscf.C
     wick_uscf.C

--- a/libgnme/wick/one_body_rscf.h
+++ b/libgnme/wick/one_body_rscf.h
@@ -42,6 +42,11 @@ private:
     void initialise(wick_orbitals<Tc,Tb> &orb, arma::Mat<Tf> &F);
 };
 
+extern template class one_body_rscf<double, double, double>;
+extern template class one_body_rscf<std::complex<double>, double, double>;
+extern template class one_body_rscf<std::complex<double>, std::complex<double>, double>;
+extern template class one_body_rscf<std::complex<double>, std::complex<double>, std::complex<double> >;
+
 } // namespace libgnme
 
 #endif // LIBGNME_ONE_BODY_RSCF_H

--- a/libgnme/wick/one_body_uscf.h
+++ b/libgnme/wick/one_body_uscf.h
@@ -69,6 +69,11 @@ private:
         arma::Mat<Tf> &Fb);
 };
 
+extern template class one_body_uscf<double, double, double>;
+extern template class one_body_uscf<std::complex<double>, double, double>;
+extern template class one_body_uscf<std::complex<double>, std::complex<double>, double>;
+extern template class one_body_uscf<std::complex<double>, std::complex<double>, std::complex<double> >;
+
 } // namespace libgnme
 
 #endif // LIBGNME_ONE_BODY_USCF_H

--- a/libgnme/wick/two_body_rscf.C
+++ b/libgnme/wick/two_body_rscf.C
@@ -94,4 +94,9 @@ void two_body_rscf<Tc,Tf,Tb>::initialise(
     }
 }
 
+template class two_body_rscf<double, double, double>;
+template class two_body_rscf<std::complex<double>, double, double>;
+template class two_body_rscf<std::complex<double>, std::complex<double>, double>;
+template class two_body_rscf<std::complex<double>, std::complex<double>, std::complex<double> >;
+
 } // namespace libgnme

--- a/libgnme/wick/two_body_rscf.h
+++ b/libgnme/wick/two_body_rscf.h
@@ -52,10 +52,10 @@ private:
     void initialise(wick_orbitals<Tc,Tb> &orb, arma::Mat<Tb> &V);
 };
 
-template class two_body_rscf<double, double, double>;
-template class two_body_rscf<std::complex<double>, double, double>;
-template class two_body_rscf<std::complex<double>, std::complex<double>, double>;
-template class two_body_rscf<std::complex<double>, std::complex<double>, std::complex<double> >;
+extern template class two_body_rscf<double, double, double>;
+extern template class two_body_rscf<std::complex<double>, double, double>;
+extern template class two_body_rscf<std::complex<double>, std::complex<double>, double>;
+extern template class two_body_rscf<std::complex<double>, std::complex<double>, std::complex<double> >;
 
 } // namespace libgnme
 

--- a/libgnme/wick/two_body_uscf.h
+++ b/libgnme/wick/two_body_uscf.h
@@ -64,6 +64,11 @@ private:
         arma::Mat<Tb> &V);
 };
 
+extern template class two_body_uscf<double, double, double>;
+extern template class two_body_uscf<std::complex<double>, double, double>;
+extern template class two_body_uscf<std::complex<double>, std::complex<double>, double>;
+extern template class two_body_uscf<std::complex<double>, std::complex<double>, std::complex<double> >;
+
 } // namespace libgnme
 
 #endif // LIBGNME_WICK_TWO_BODY_USCF_H

--- a/libgnme/wick/wick_base.C
+++ b/libgnme/wick/wick_base.C
@@ -1,0 +1,15 @@
+#include "wick_base.h"
+#include "wick_base_one_body.h"
+#include "wick_base_overlap.h"
+#include "wick_base_rdm.h"
+#include "wick_base_two_body.h"
+
+
+namespace libgnme {
+
+template class wick_base<double, double, double>;
+template class wick_base<std::complex<double>, double, double>;
+template class wick_base<std::complex<double>, std::complex<double>, double>;
+template class wick_base<std::complex<double>, std::complex<double>, std::complex<double> >;
+
+} // namespace libgnme

--- a/libgnme/wick/wick_base.h
+++ b/libgnme/wick/wick_base.h
@@ -137,6 +137,11 @@ protected:
         Tc &V);
 };
 
+extern template class wick_base<double, double, double>;
+extern template class wick_base<std::complex<double>, double, double>;
+extern template class wick_base<std::complex<double>, std::complex<double>, double>;
+extern template class wick_base<std::complex<double>, std::complex<double>, std::complex<double> >;
+
 } // namespace libgnme
 
 #endif // LIBGNME_WICK_BASE_H

--- a/libgnme/wick/wick_base_one_body.h
+++ b/libgnme/wick/wick_base_one_body.h
@@ -120,9 +120,4 @@ void wick_base<Tc,Tf,Tb>::spin_one_body(
     return;
 }
 
-template class wick_base<double, double, double>;
-template class wick_base<std::complex<double>, double, double>;
-template class wick_base<std::complex<double>, std::complex<double>, double>;
-template class wick_base<std::complex<double>, std::complex<double>, std::complex<double> >;
-
 } // namespace libgnme

--- a/libgnme/wick/wick_base_overlap.h
+++ b/libgnme/wick/wick_base_overlap.h
@@ -81,9 +81,4 @@ void wick_base<Tc,Tf,Tb>::spin_overlap(
     return;
 }
 
-template class wick_base<double, double, double>;
-template class wick_base<std::complex<double>, double, double>;
-template class wick_base<std::complex<double>, std::complex<double>, double>;
-template class wick_base<std::complex<double>, std::complex<double>, std::complex<double> >;
-
 } // namespace libgnme

--- a/libgnme/wick/wick_base_rdm.h
+++ b/libgnme/wick/wick_base_rdm.h
@@ -395,9 +395,4 @@ void wick_base<Tc,Tf,Tb>::diff_spin_rdm2(
     }
 }
 
-template class wick_base<double, double, double>;
-template class wick_base<std::complex<double>, double, double>;
-template class wick_base<std::complex<double>, std::complex<double>, double>;
-template class wick_base<std::complex<double>, std::complex<double>, std::complex<double> >;
-
 } // namespace libgnme

--- a/libgnme/wick/wick_base_two_body.h
+++ b/libgnme/wick/wick_base_two_body.h
@@ -426,9 +426,4 @@ void wick_base<Tc,Tf,Tb>::diff_spin_two_body(
     wbhp -= nactxb;
 }
 
-template class wick_base<double, double, double>;
-template class wick_base<std::complex<double>, double, double>;
-template class wick_base<std::complex<double>, std::complex<double>, double>;
-template class wick_base<std::complex<double>, std::complex<double>, std::complex<double> >;
-
 } // namespace libgnme


### PR DESCRIPTION
Link-time errors were discovered on macOS when GCC was used. Neither GCC nor Clang on Linux have this issue, nor does Apple Clang on macOS.

I think the issue was caused by code that does not conform to the standard. Specifically, the requirements specified in [[temp.spec.general]/5.1](https://eel.is/c++draft/temp.spec.general#5.1) and [[temp.explicit]/7](https://eel.is/c++draft/temp.explicit#7) of the C++ standard were not met. Additionally, in some instances, *extern template*s should be used instead of simple *explicit template instantiation*s, but this was not done, causing some templated classes to be treated as incomplete, which contributes to the link-time errors also.

Although the linking issue was only observed on macOS with GCC, for now. The real issue, however, is non-standard conforming code. This means that even if everything seems to be working properly, the library and program are still ill-formed.

The present PR should fix the issue, with only relatively minor code changes.